### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/enarksh/Controller/Node/SimpleNode.py
+++ b/enarksh/Controller/Node/SimpleNode.py
@@ -49,6 +49,6 @@ class SimpleNode(Node):
             self._recompute_run_status()
 
         else:
-            raise Exception("Not possible to restart node with rst_id '%s'." % self.rst_id)
+            raise Exception("Not possible to restart node with rst_id '{0!s}'.".format(self.rst_id))
 
 # ----------------------------------------------------------------------------------------------------------------------

--- a/enarksh/Controller/Resource/ReadWriteLockResource.py
+++ b/enarksh/Controller/Resource/ReadWriteLockResource.py
@@ -61,7 +61,7 @@ class ReadWriteLockResource(Resource):
             self._read_write_lock_count += 1
 
         else:
-            raise Exception("Unknown rws_id '%s'." % rws_id)
+            raise Exception("Unknown rws_id '{0!s}'.".format(rws_id))
 
     # ------------------------------------------------------------------------------------------------------------------
     def inquire(self, rws_id: int) -> bool:
@@ -79,7 +79,7 @@ class ReadWriteLockResource(Resource):
             # resource.
             return self._read_write_lock_count == 0 and self._read_lock_count == 0
 
-        raise Exception("Unknown rws_id '%s'." % rws_id)
+        raise Exception("Unknown rws_id '{0!s}'.".format(rws_id))
 
     # ------------------------------------------------------------------------------------------------------------------
     @StateChange.wrapper
@@ -96,7 +96,7 @@ class ReadWriteLockResource(Resource):
             self._read_write_lock_count -= 1
 
         else:
-            raise Exception("Unknown rws_id '%s'." % rws_id)
+            raise Exception("Unknown rws_id '{0!s}'.".format(rws_id))
 
     # ------------------------------------------------------------------------------------------------------------------
     def sync_state(self):

--- a/enarksh/DataLayer.py
+++ b/enarksh/DataLayer.py
@@ -89,7 +89,7 @@ class DataLayer(StaticDataLayer):
         rows = StaticDataLayer.execute_sp_rows("call enk_back_run_get_ports1(%s)", p_run_id)
         for row in rows:
             if row['prt_id'] in ret:
-                raise Exception('Duplicate key for %s.' % str((row['prt_id'])))
+                raise Exception('Duplicate key for {0!s}.'.format(str((row['prt_id']))))
             else:
                 ret[row['prt_id']] = row
 
@@ -128,7 +128,7 @@ class DataLayer(StaticDataLayer):
         rows = StaticDataLayer.execute_sp_rows("call enk_back_run_get_run_nodes(%s)", p_run_id)
         for row in rows:
             if row['rnd_id'] in ret:
-                raise Exception('Duplicate key for %s.' % str((row['rnd_id'])))
+                raise Exception('Duplicate key for {0!s}.'.format(str((row['rnd_id']))))
             else:
                 ret[row['rnd_id']] = row
 

--- a/enarksh/Spawner/ChunkLogger.py
+++ b/enarksh/Spawner/ChunkLogger.py
@@ -17,7 +17,7 @@ class ChunkLogger:
     def _get_filename():
         ChunkLogger._file_count += 1
 
-        return '%s/%s/%010d.log' % (enarksh.HOME, 'var/lib/logger', ChunkLogger._file_count)
+        return '{0!s}/{1!s}/{2:010d}.log'.format(enarksh.HOME, 'var/lib/logger', ChunkLogger._file_count)
 
     # ------------------------------------------------------------------------------------------------------------------
     def write(self, buffer: bytes):

--- a/enarksh/Spawner/Spawner.py
+++ b/enarksh/Spawner/Spawner.py
@@ -179,7 +179,7 @@ class Spawner:
                                                    message['args'])
 
                 else:
-                    raise IndexError("Unknown message type '%s'." % message['type'])
+                    raise IndexError("Unknown message type '{0!s}'.".format(message['type']))
 
         except zmq.ZMQError as e:
             # Ignore ZMQError with EAGAIN. Otherwise, re-raise the error.

--- a/enarksh/XmlReader/Consumption/Consumption.py
+++ b/enarksh/XmlReader/Consumption/Consumption.py
@@ -47,7 +47,7 @@ class Consumption:
             self._resource_name = xml.text
 
         else:
-            raise Exception("Unexpected tag '%s'." % tag)
+            raise Exception("Unexpected tag '{0!s}'.".format(tag))
 
     # ------------------------------------------------------------------------------------------------------------------
     def get_uri(self, obj_type: str='consumption') -> str:

--- a/enarksh/XmlReader/Consumption/CountingConsumption.py
+++ b/enarksh/XmlReader/Consumption/CountingConsumption.py
@@ -42,7 +42,7 @@ class CountingConsumption(Consumption):
         if not resource:
             err = {'uri': self.get_uri(),
                    'rule': 'A consumption requires a resource.',
-                   'error': "Resource '%s' not found." % self._resource_name}
+                   'error': "Resource '{0!s}' not found.".format(self._resource_name)}
             errors.append(err)
             return
 
@@ -51,8 +51,7 @@ class CountingConsumption(Consumption):
             # resource is not a valid resource for this consumption.
             err = {'uri': self.get_uri(),
                    'rule': 'A consumption requires a corresponding resource type.',
-                   'error': "Found a resource of type '%s', expecting a resource of type 'CountingResource'."
-                            % resource_type}
+                   'error': "Found a resource of type '{0!s}', expecting a resource of type 'CountingResource'.".format(resource_type)}
             errors.append(err)
 
     # ------------------------------------------------------------------------------------------------------------------

--- a/enarksh/XmlReader/Consumption/ReadWriteLockConsumption.py
+++ b/enarksh/XmlReader/Consumption/ReadWriteLockConsumption.py
@@ -35,7 +35,7 @@ class ReadWriteLockConsumption(Consumption):
                 self.rws_id = enarksh.ENK_RWS_ID_WRITE
 
             else:
-                raise Exception("Unexpected mode '%s'." % mode)
+                raise Exception("Unexpected mode '{0!s}'.".format(mode))
 
         else:
             Consumption.read_xml_element(self, xml)
@@ -50,7 +50,7 @@ class ReadWriteLockConsumption(Consumption):
         if not resource:
             err = {'uri': self.get_uri(),
                    'rule': 'A consumption requires a resource.',
-                   'error': "Resource '%s' not found." % self._resource_name}
+                   'error': "Resource '{0!s}' not found.".format(self._resource_name)}
             errors.append(err)
             return
 
@@ -59,8 +59,7 @@ class ReadWriteLockConsumption(Consumption):
             # resource is not a valid resource for this consumption.
             err = {'uri': self.get_uri(),
                    'rule': 'A consumption requires a corresponding resource type.',
-                   'error': "Found a resource of type '%s', expecting a resource of type 'ReadWriteLockResource'."
-                            % resource_type}
+                   'error': "Found a resource of type '{0!s}', expecting a resource of type 'ReadWriteLockResource'.".format(resource_type)}
             errors.append(err)
 
     # ------------------------------------------------------------------------------------------------------------------

--- a/enarksh/XmlReader/Dependency.py
+++ b/enarksh/XmlReader/Dependency.py
@@ -48,7 +48,7 @@ class Dependency:
                 self._port_name = element.text
 
             else:
-                raise Exception("Unexpected tag '%s'." % tag)
+                raise Exception("Unexpected tag '{0!s}'.".format(tag))
 
     # ------------------------------------------------------------------------------------------------------------------
     def validate(self, errors: list) -> None:

--- a/enarksh/XmlReader/Host.py
+++ b/enarksh/XmlReader/Host.py
@@ -68,7 +68,7 @@ class Host:
                 self._read_xml_resources(element)
 
             else:
-                raise Exception("Unexpected tag '%s'." % tag)
+                raise Exception("Unexpected tag '{0!s}'.".format(tag))
 
     # ------------------------------------------------------------------------------------------------------------------
     def validate(self) -> str:
@@ -87,7 +87,7 @@ class Host:
         if self._hostname != 'localhost':
             err = {'uri': self.get_uri(),
                    'rule': 'Currently, only localhost is supported.',
-                   'error': "Hostname must be 'localhost', found: '%s'." % self._hostname}
+                   'error': "Hostname must be 'localhost', found: '{0!s}'.".format(self._hostname)}
             errors.append(err)
 
     # ------------------------------------------------------------------------------------------------------------------
@@ -133,13 +133,13 @@ class Host:
                 resource = ReadWriteLockResource(self)
 
             else:
-                raise Exception("Unexpected tag '%s'." % tag)
+                raise Exception("Unexpected tag '{0!s}'.".format(tag))
 
             resource.read_xml(element)
             name = resource.get_name()
             # Check for resources with duplicate names.
             if name in self._resources:
-                raise Exception("Duplicate resource '%s'." % name)
+                raise Exception("Duplicate resource '{0!s}'.".format(name))
 
             self._resources[name] = resource
 

--- a/enarksh/XmlReader/Node/CommandJobNode.py
+++ b/enarksh/XmlReader/Node/CommandJobNode.py
@@ -20,7 +20,7 @@ class CommandJobNode(SimpleNode):
             self._args.append(xml.text)
 
         else:
-            raise Exception("Unexpected tag '%s'." % tag)
+            raise Exception("Unexpected tag '{0!s}'.".format(tag))
 
     # ------------------------------------------------------------------------------------------------------------------
     def read_xml_element(self, xml: Element) -> None:

--- a/enarksh/XmlReader/Node/ComplexNode.py
+++ b/enarksh/XmlReader/Node/ComplexNode.py
@@ -115,7 +115,7 @@ class ComplexNode(Node):
 
             # Check for child nodes with duplicate names.
             if name in self._child_nodes:
-                raise Exception("Duplicate child node '%s'." % name)
+                raise Exception("Duplicate child node '{0!s}'.".format(name))
 
             # Add child node to map of child nodes.
             self._child_nodes[name] = node
@@ -131,13 +131,13 @@ class ComplexNode(Node):
                 resource = ReadWriteLockResource(self)
 
             else:
-                raise Exception("Unexpected tag '%s'." % tag)
+                raise Exception("Unexpected tag '{0!s}'.".format(tag))
 
             resource.read_xml(element)
             name = resource.get_name()
             # Check for resources with duplicate names.
             if name in self._resources:
-                raise Exception("Duplicate resource '%s'." % name)
+                raise Exception("Duplicate resource '{0!s}'.".format(name))
 
             self._resources[name] = resource
 

--- a/enarksh/XmlReader/Node/DynamicInnerWorkerNode.py
+++ b/enarksh/XmlReader/Node/DynamicInnerWorkerNode.py
@@ -37,14 +37,14 @@ class DynamicInnerWorkerNode(CompoundJobNode):
         if len(self._input_ports) != 1:
             err = {'uri': self.get_uri(),
                    'rule': 'A worker node must have one and only one input port.',
-                   'error': "Node has %d input ports.'." % len(self._input_ports)}
+                   'error': "Node has {0:d} input ports.'.".format(len(self._input_ports))}
             errors.append(err)
 
         # Validate worker node has one and only one output port.
         if len(self._output_ports) != 1:
             err = {'uri': self.get_uri(),
                    'rule': 'A worker node must have one and only one output port.',
-                   'error': "Node has %d output ports.'." % len(self._output_ports)}
+                   'error': "Node has {0:d} output ports.'.".format(len(self._output_ports))}
             errors.append(err)
 
     # ------------------------------------------------------------------------------------------------------------------

--- a/enarksh/XmlReader/Node/DynamicJobNode.py
+++ b/enarksh/XmlReader/Node/DynamicJobNode.py
@@ -140,7 +140,7 @@ class DynamicJobNode(Node):
         if node_name == self._worker._node_name:
             return self._worker
 
-        raise Exception("Unknown node '%s'." % node_name)
+        raise Exception("Unknown node '{0!s}'.".format(node_name))
 
 
 # ----------------------------------------------------------------------------------------------------------------------

--- a/enarksh/XmlReader/Node/DynamicOuterWorkerNode.py
+++ b/enarksh/XmlReader/Node/DynamicOuterWorkerNode.py
@@ -37,14 +37,14 @@ class DynamicOuterWorkerNode(ComplexNode):
         if len(self._input_ports) != 1:
             err = {'uri': self.get_uri(),
                    'rule': 'A worker node must have one and only one input port.',
-                   'error': "Node has %d input ports.'." % len(self._input_ports)}
+                   'error': "Node has {0:d} input ports.'.".format(len(self._input_ports))}
             errors.append(err)
 
         # Validate worker node has one and only one output port.
         if len(self._output_ports) != 1:
             err = {'uri': self.get_uri(),
                    'rule': 'A worker node must have one and only one output port.',
-                   'error': "Node has %d output ports.'." % len(self._output_ports)}
+                   'error': "Node has {0:d} output ports.'.".format(len(self._output_ports))}
             errors.append(err)
 
 

--- a/enarksh/XmlReader/Node/Node.py
+++ b/enarksh/XmlReader/Node/Node.py
@@ -106,7 +106,7 @@ class Node:
             self._read_xml_output_ports(xml)
 
         else:
-            raise Exception("Unexpected tag '%s'." % tag)
+            raise Exception("Unexpected tag '{0!s}'.".format(tag))
 
     # ------------------------------------------------------------------------------------------------------------------
     def _read_xml_consumptions(self, xml: Element) -> None:
@@ -119,13 +119,13 @@ class Node:
                 consumption = ReadWriteLockConsumption(self)
 
             else:
-                raise Exception("Unexpected tag '%s'." % tag)
+                raise Exception("Unexpected tag '{0!s}'.".format(tag))
 
             consumption.read_xml(element)
             name = consumption.get_name()
             # Check for consumptions with duplicate names.
             if name in self._consumptions:
-                raise Exception("Duplicate consumption '%s'." % name)
+                raise Exception("Duplicate consumption '{0!s}'.".format(name))
 
             self._consumptions[name] = consumption
 
@@ -140,12 +140,12 @@ class Node:
                 name = port.get_name()
                 # Check for ports with duplicate names.
                 if name in self._input_ports:
-                    raise Exception("Duplicate input port '%s'." % name)
+                    raise Exception("Duplicate input port '{0!s}'.".format(name))
 
                 self._input_ports[name] = port
 
             else:
-                raise Exception("Unexpected tag '%s'." % tag)
+                raise Exception("Unexpected tag '{0!s}'.".format(tag))
 
     # ------------------------------------------------------------------------------------------------------------------
     def _read_xml_output_ports(self, xml: Element) -> None:
@@ -158,12 +158,12 @@ class Node:
                 name = port.get_name()
                 # Check for ports with duplicate names.
                 if name in self._output_ports:
-                    raise Exception("Duplicate output port '%s'." % name)
+                    raise Exception("Duplicate output port '{0!s}'.".format(name))
 
                 self._output_ports[name] = port
 
             else:
-                raise Exception("Unexpected tag '%s'." % tag)
+                raise Exception("Unexpected tag '{0!s}'.".format(tag))
 
     # ------------------------------------------------------------------------------------------------------------------
     @abc.abstractmethod

--- a/enarksh/XmlReader/Port/Port.py
+++ b/enarksh/XmlReader/Port/Port.py
@@ -70,7 +70,7 @@ class Port:
             self._read_xml_dependencies(xml)
 
         else:
-            raise Exception("Unexpected tag '%s'." % tag)
+            raise Exception("Unexpected tag '{0!s}'.".format(tag))
 
     # ------------------------------------------------------------------------------------------------------------------
     def _read_xml_dependencies(self, xml: Element) -> None:
@@ -82,7 +82,7 @@ class Port:
                 self._dependencies.append(dependency)
 
             else:
-                raise Exception("Unexpected tag '%s'." % tag)
+                raise Exception("Unexpected tag '{0!s}'.".format(tag))
 
     # ------------------------------------------------------------------------------------------------------------------
     def validate(self, errors: list) -> None:

--- a/enarksh/XmlReader/XmlReader.py
+++ b/enarksh/XmlReader/XmlReader.py
@@ -32,13 +32,13 @@ class XmlReader:
 
             # Root element must be a schedule.
             if root.tag != 'Schedule':
-                raise Exception("Root element must be 'Schedule' but '%s' was found." % root.tag)
+                raise Exception("Root element must be 'Schedule' but '{0!s}' was found.".format(root.tag))
 
             schedule = create_node('Schedule')
             schedule.read_xml(root)
             error = schedule.validate()
             if error:
-                raise Exception("File '%s' is not a valid schedule configuration file.\n%s" % (filename, error))
+                raise Exception("File '{0!s}' is not a valid schedule configuration file.\n{1!s}".format(filename, error))
 
             # Set recursion and dependency levels.
             schedule.set_levels()
@@ -65,13 +65,13 @@ class XmlReader:
 
         # Root element must be a dynamic inner worker.
         if root.tag != 'DynamicInnerWorker':
-            raise Exception("Root element must be 'DynamicInnerWorker' but '%s' was found." % root.tag)
+            raise Exception("Root element must be 'DynamicInnerWorker' but '{0!s}' was found.".format(root.tag))
 
         worker = create_node('DynamicInnerWorker')
         worker.read_xml(root)
         error = worker.validate(parent)
         if error:
-            raise Exception("XML message is not a valid dynamic worker configuration.\n%s" % error)
+            raise Exception("XML message is not a valid dynamic worker configuration.\n{0!s}".format(error))
 
         # Set recursion and dependency levels.
         worker.set_levels()
@@ -99,13 +99,13 @@ class XmlReader:
 
         # Root element must be a schedule.
         if root.tag != 'Host':
-            raise Exception("Root element must be 'Host' but '%s' was found." % root.tag)
+            raise Exception("Root element must be 'Host' but '{0!s}' was found.".format(root.tag))
 
         host = Host()
         host.read_xml(root)
         error = host.validate()
         if error:
-            raise Exception("File '%s' is not a valid host configuration file.\n%s" % (filename, error))
+            raise Exception("File '{0!s}' is not a valid host configuration file.\n{1!s}".format(filename, error))
 
         return host
 


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:SetBased:py-enarksh?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:SetBased:py-enarksh?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
